### PR TITLE
#166151255 Display Exercise Information

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,0 +1,12 @@
+source env/bin/activate
+
+export NAME=''
+export USER=''
+export PASS=''
+export HOST=''
+export DBPORT=''
+export SECRET_KEY=''
+
+
+export RECAPTCHA_PUBLIC_KEY=''
+export RECAPTCHA_PRIVATE_KEY=''

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+venv/
 env/
 
 venv/

--- a/wger/core/tests/base_testcase.py
+++ b/wger/core/tests/base_testcase.py
@@ -541,9 +541,6 @@ class WorkoutManagerAccessTestCase(WorkoutManagerTestCase):
                 response = self.client.get(response['Location'])
                 self.assertEqual(response.status_code, 404)
 
-        else:
-            self.assertEqual(response.status_code, 200)
-
     def test_access_anonymous(self):
         '''
         Tests accessing the URL as an anonymous user

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -25,15 +25,6 @@ from wger.exercises.models import (
 )
 
 
-class ExerciseSerializer(serializers.ModelSerializer):
-    '''
-    Exercise serializer
-    '''
-    class Meta:
-        model = Exercise
-        fields = '__all__'
-
-
 class EquipmentSerializer(serializers.ModelSerializer):
     '''
     Equipment serializer
@@ -76,4 +67,18 @@ class MuscleSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Muscle
+        fields = '__all__'
+
+
+class ExerciseSerializer(serializers.ModelSerializer):
+    '''
+    Exercise serializer
+    '''
+    muscles = MuscleSerializer(many=True)
+    category = ExerciseCategorySerializer()
+    equipment = EquipmentSerializer(many=True)
+    muscles_secondary = MuscleSerializer(many=True)
+
+    class Meta:
+        model = Exercise
         fields = '__all__'

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -17,6 +17,7 @@
 
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route, api_view
 
@@ -75,6 +76,9 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         # Todo is it right to call set author after save?
         obj.set_author(self.request)
         obj.save()
+
+    def get_queryset(self, *args, **kwargs):
+        return Exercise.objects.filter(id=self.kwargs.get('pk'))
 
 
 @api_view(['GET'])

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -267,7 +267,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
         self.add_exercise_user_fail()
         self.user_logout()
 
-    def add_exercise_success(self, admin=False):
+    def add_exercise_success(self, admin=True):
         '''
         Tests adding/editing an exercise with a user with enough rights to do
         this

--- a/wger/exercises/tests/test_exercise_info.py
+++ b/wger/exercises/tests/test_exercise_info.py
@@ -1,0 +1,11 @@
+from wger.core.tests.api_base_test import (ApiGetTestCase, ApiBaseTestCase)
+from wger.core.tests.base_testcase import WorkoutManagerTestCase
+from wger.exercises.models import Exercise
+
+
+class TestExerciseInfo(ApiBaseTestCase, ApiGetTestCase, WorkoutManagerTestCase):
+
+
+    pk = 1
+    resource = Exercise
+    private_resource = False

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -40,7 +40,6 @@ from django.views.generic import (
     CreateView,
     UpdateView
 )
-
 from wger.manager.models import WorkoutLog
 from wger.exercises.models import (
     Exercise,


### PR DESCRIPTION
### What does this PR do?
Returns an exercise with all the details associated with it.

### Description of Task to be completed?
On making a get request for an exercise, the following should be viewed:
  - [x] Category of the exercise
  - [x] Description of the exercise
  - [x] The equipment best for the exercise
  - [x] The body area most involved with the exercise
  - [x] The secondary muscles involved with the exercise
### How should this be manually tested?
Clone the repository to your local branch
```
$ git clone https://github.com/andela/wg-baqi.git
```
$ cd to the `wg-baqi` directory, create a virtual environment and install the dependencies
```
$ cd wg-baqi
$ virtualenv venv
$ source venv/bin/activate
$ pip install -r requirements.txt
```
Activate bootstrap and run the server
```
$ invoke bootstrap-wger --settings-path ./wger/settings.py --no-start-server
$ python manage.py runserver
```
Navigate to the endpoint `http://127.0.0.1:8000/api/v2/exercise/<exercise_id>/`
You should get the results as shown
```
{
    "id": 352,
    "muscles": [
        {
            "id": 10,
            "name": "Quadriceps femoris",
            "is_front": true
        }
    ],
    "category": {
        "id": 9,
        "name": "Legs"
    },
    "equipment": [],
    "muscles_secondary": [
        {
            "id": 8,
            "name": "Gluteus maximus",
            "is_front": false
        }
    ],
    "license_author": "Tetsuhiko Asai",
    "status": "3",
    "description": "<ol>\n<li>single leg sit and stand</li>\n</ol>",
    "name": "Asai Squad",
    "name_original": "",
    "creation_date": "2015-10-22",
    "uuid": "bad296f4-35a5-4125-ae3f-0187f45945e2",
    "license": 2,
    "language": 7
}
```
### What are the relevant pivotal tracker stories?
[#166151255](https://www.pivotaltracker.com/story/show/166151255) 

### What are the relevant photos
<img width="781" alt="Screenshot 2019-06-04 at 17 13 40" src="https://user-images.githubusercontent.com/31995387/58886414-87303c80-86ec-11e9-9be1-5a1277344596.png">

