### PR TITLE
#166151267 Change how meals are added

### DIFF
--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -128,6 +128,9 @@ class MealItemForm(forms.ModelForm):
         required=False)
     ingredient = forms.ModelChoiceField(queryset=Ingredient.objects.all(),
                                         widget=forms.HiddenInput)
+    time = forms.TimeField(required=False,
+                           label=_('Time'),
+                           widget=forms.TimeInput)
 
     class Meta:
         model = MealItem

--- a/wger/nutrition/templates/meal_item/edit.html
+++ b/wger/nutrition/templates/meal_item/edit.html
@@ -4,8 +4,14 @@
 {% load wger_extras %}
 
 
-{% block title %}{% trans "Edit meal item" %}{% endblock %}
+{% block title %}
+    {% if plan_pk %}
+        {% trans "Add new meal" %}
+    {% else %}
+        {% trans "Edit meal item" %}
+    {% endif %}
 
+ {% endblock %}
 
 {% block header %}
 <script type="text/javascript">
@@ -26,6 +32,9 @@ $(document).ready(function() {
     {% csrf_token %}
     {% render_form_errors form %}
     {{form.ingredient}}
+    {% if plan_pk %}
+        {% render_form_field form.time %}
+    {% endif %}
 
     <div class="form-group {% if field.errors %}has-error{% endif %}" id="form-id_ingredient_searchfield">
         <label for="id_ingredient_searchfield" class="col-md-3 control-label">

--- a/wger/nutrition/templates/plan/view.html
+++ b/wger/nutrition/templates/plan/view.html
@@ -133,7 +133,7 @@ function wgerCustomModalInit()
 {% empty %}
 {% if is_owner %}
 <p>
-     <a href="{% url 'nutrition:meal:add' plan.id %}"
+     <a href="{% url 'nutrition:meal_item:add-meal' plan.id %}"
         class="wger-modal-dialog btn btn-default btn-block">
             {% trans "No meals for this plan." %}
             {% trans "Add one now." %}
@@ -144,7 +144,7 @@ function wgerCustomModalInit()
         {% if is_owner %}
         <tr>
             <td colspan="6">
-            <a href="{% url 'nutrition:meal:add' plan.id %}"
+            <a href="{% url 'nutrition:meal_item:add-meal' plan.id %}"
                class="wger-modal-dialog">
                 <span class="{% fa_class 'plus' %}"></span>
                 {% trans "Add a new meal" %}

--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -62,6 +62,34 @@ class AddMealTestCase(WorkoutManagerAddTestCase):
     user_fail = 'admin'
 
 
+class AddNewMealTestCase(WorkoutManagerTestCase):
+    '''
+    Tests adding a Meal and meal item at the same time
+    '''
+
+    def test_add_new_meal(self):
+        self.user_login('admin')
+
+        url = reverse('nutrition:meal_item:add-meal',
+                      kwargs={'plan_pk': 5})
+        data = {'amount': 1,
+                'ingredient': 1,
+                'weight_unit': 1,
+                'time': datetime.time(9, 5)}
+
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)  # redirects on success
+
+        # check view to confirm meal plan was posted
+        response = self.client.get(
+            reverse('nutrition:plan:view', kwargs={'id': 5})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '09:05')
+
+        self.user_logout()
+
+
 class PlanOverviewTestCase(WorkoutManagerTestCase):
     '''
     Tests the nutrition plan overview

--- a/wger/nutrition/urls.py
+++ b/wger/nutrition/urls.py
@@ -86,6 +86,9 @@ patterns_meal_item = [
     url(r'^(?P<item_id>\d+)/delete/$',
         meal_item.delete_meal_item,
         name='delete'),
+    url(r'^(?P<plan_pk>\d+)/meal/add/$',
+        login_required(meal_item.MealItemCreateView.as_view()),
+        name='add-meal'),
 ]
 
 

--- a/wger/nutrition/views/meal_item.py
+++ b/wger/nutrition/views/meal_item.py
@@ -23,7 +23,7 @@ from django.utils.translation import ugettext_lazy
 from django.views.generic import CreateView, UpdateView
 
 from wger.nutrition.forms import MealItemForm
-from wger.nutrition.models import Meal, MealItem
+from wger.nutrition.models import Meal, MealItem, NutritionPlan
 from wger.utils.generic_views import WgerFormMixin
 
 
@@ -62,13 +62,19 @@ class MealItemCreateView(WgerFormMixin, CreateView):
         '''
         Check that the user owns the meal
         '''
-        meal = get_object_or_404(Meal, pk=kwargs['meal_id'])
-        if meal.plan.user == request.user:
-            self.meal = meal
-            return super(MealItemCreateView,
-                         self).dispatch(request, *args, **kwargs)
+        self.meal_id = kwargs.get('meal_id')
+        self.plan_pk = kwargs.get('plan_pk')
+        if self.meal_id:
+            meal = get_object_or_404(Meal, pk=self.meal_id)
+            if meal.plan.user == request.user:
+                self.meal = meal
+                return super(
+                    MealItemCreateView, self).dispatch(request, *args, **kwargs)
+            else:
+                return HttpResponseForbidden()
         else:
-            return HttpResponseForbidden()
+            return super(
+                MealItemCreateView, self).dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
         return reverse('nutrition:plan:view', kwargs={'id': self.meal.plan.id})
@@ -78,16 +84,29 @@ class MealItemCreateView(WgerFormMixin, CreateView):
         Send some additional data to the template
         '''
         context = super(MealItemCreateView, self).get_context_data(**kwargs)
-        context['form_action'] = reverse('nutrition:meal_item:add',
-                                         kwargs={'meal_id': self.meal.id})
-        context['ingredient_searchfield'
-                ] = self.request.POST.get('ingredient_searchfield', '')
+
+        if self.meal_id:
+            context['form_action'] = reverse('nutrition:meal_item:add',
+                                             kwargs={'meal_id': self.meal.id})
+        else:
+            context['form_action'] = reverse('nutrition:meal_item:add-meal',
+                                             kwargs={'plan_pk': self.plan_pk})
+        context['ingredient_searchfield'] =\
+            self.request.POST.get('ingredient_searchfield', '')
+        context['plan_pk'] = self.plan_pk
         return context
 
     def form_valid(self, form):
         '''
         Manually set the corresponding meal
         '''
+        if not self.meal_id:
+            plan = get_object_or_404(
+                NutritionPlan, pk=self.plan_pk, user=self.request.user)
+            self.meal = Meal.objects.create(plan=plan, order=1)
+            self.meal.time = form.cleaned_data['time']
+            self.meal.save()
+
         form.instance.meal = self.meal
         form.instance.order = 1
         return super(MealItemCreateView, self).form_valid(form)


### PR DESCRIPTION
### What does this PR do?
Allows user to add both time and meal simultaneously.

### Description of Task to be completed?
- [x] Add single form for adding both meal time and meal items.

### How should this be manually tested?
* Start server by running `python manage.py runserver`
* Navigate to `http://127.0.0.1:8000/en/dashboard`
* Click on `Nutrition` -> `Nutrition plans`
* Click on `Sample nutrition plan`
* Click on `+ Add a new meal`. Note that ingredients should be selected from the dropdown list. Start typing a meal and wait for suggestions, then select from the available list.
* Add new meal and click `Save`. Note that time should be added in 24hr format e.g 22:04

### What are the relevant pivotal tracker stories?
[#166151267](https://www.pivotaltracker.com/story/show/166151267) 

### Screenshots
#### Before
<img width="1181" alt="Screenshot 2019-06-13 at 08 37 31" src="https://user-images.githubusercontent.com/19375569/59406372-95e6b580-8db6-11e9-84f3-1e24ffe010b3.png">

#### After
<img width="1186" alt="Screenshot 2019-06-12 at 10 09 31" src="https://user-images.githubusercontent.com/19375569/59330465-34f9a780-8cfa-11e9-9748-1335abf17264.png">
