### PR TITLE
#166573650 Fix get all exercises endpoint

### DIFF
--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -23,6 +23,7 @@ from rest_framework.decorators import detail_route, api_view
 
 from easy_thumbnails.alias import aliases
 from easy_thumbnails.files import get_thumbnailer
+from django.shortcuts import get_object_or_404
 
 from django.utils.translation import ugettext as _
 
@@ -47,7 +48,7 @@ from wger.utils.language import load_item_languages, load_language
 from wger.utils.permissions import CreateOnlyPermission
 
 
-class ExerciseViewSet(viewsets.ModelViewSet):
+class ExerciseViewSet(viewsets.ViewSet):
     '''
     API endpoint for exercise objects
     '''
@@ -77,8 +78,14 @@ class ExerciseViewSet(viewsets.ModelViewSet):
         obj.set_author(self.request)
         obj.save()
 
-    def get_queryset(self, *args, **kwargs):
-        return Exercise.objects.filter(id=self.kwargs.get('pk'))
+    def list(self, request):
+        serializer = ExerciseSerializer(self.queryset, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        exercise = get_object_or_404(self.queryset, pk=pk)
+        serializer = ExerciseSerializer(exercise)
+        return Response(serializer.data)
 
 
 @api_view(['GET'])

--- a/wger/exercises/tests/test_exercise_info.py
+++ b/wger/exercises/tests/test_exercise_info.py
@@ -1,11 +1,66 @@
 from wger.core.tests.api_base_test import (ApiGetTestCase, ApiBaseTestCase)
 from wger.core.tests.base_testcase import WorkoutManagerTestCase
 from wger.exercises.models import Exercise
+from rest_framework.test import APITestCase
+from rest_framework import status
 
 
-class TestExerciseInfo(ApiBaseTestCase, ApiGetTestCase, WorkoutManagerTestCase):
-
+class TestExerciseInfo(
+        ApiBaseTestCase, ApiGetTestCase, WorkoutManagerTestCase):
+    """
+    Define test variables for get exercise by id
+    """
 
     pk = 1
+    resource = Exercise
+    private_resource = False
+
+
+class CustomBaseTestCase(APITestCase):
+    """
+    Test variable definitions
+    """
+
+    api_version = "v2"
+    resource = None
+    pk = None
+    private_resource = True
+
+    def get_resource_name(self):
+        """
+        Returns the name of the resource in lowercase
+        """
+
+        return self.resource.__name__.lower()
+
+    @property
+    def url(self):
+        """
+        Return the URL to use for testing
+        """
+
+        return "/api/{0}/{1}/".format(
+            self.api_version, self.get_resource_name())
+
+
+class CustomApiGetTestCase(object):
+    """
+    Base test case for testing GET access to the API
+    """
+
+    def test_get_overview(self):
+        """
+        Test accessing the overview view of a resource
+        """
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class TestAllExerciseInfo(
+        CustomBaseTestCase, CustomApiGetTestCase, WorkoutManagerTestCase):
+    """
+    Define test variables for geting all exercises
+    """
+
     resource = Exercise
     private_resource = False


### PR DESCRIPTION
#### Fix the fetch all exercise endpoint which was not working as expected
#### Steps to reproduce
After installation and the app runs, navigate to the endpoint: `http://127.0.0.1:8000/api/v2/exercise/` and make a get request.
#### Expected
All exercises should be displayed.
#### Actual
The exercises are not displayed as expected.