### PR TITLE
#166151254 cache nutritional info for plans

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -244,7 +244,7 @@ def migrate_db(context, settings_path=None):
 
     # Find the path to the settings and setup the django environment
     setup_django_environment(settings_path)
-
+    call_command("createcachetable")
     call_command("migrate")
 
 

--- a/wger/nutrition/__init__.py
+++ b/wger/nutrition/__init__.py
@@ -19,3 +19,4 @@
 from wger import get_version
 
 VERSION = get_version()
+default_app_config = 'wger.nutrition.app.Nutritionconfig'

--- a/wger/nutrition/app.py
+++ b/wger/nutrition/app.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class Nutritionconfig(AppConfig):
+        name = 'wger.nutrition'
+
+        def ready(self):
+                import wger.nutrition.signals
+                return wger.nutrition.signals

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -112,6 +112,11 @@ class NutritionPlan(models.Model):
         '''
         Sums the nutritional info of all items in the plan
         '''
+
+        cached_plans = cache.get(str(self.id))
+        if cached_plans:
+            return cached_plans
+
         use_metric = self.user.userprofile.use_metric
         unit = 'kg' if use_metric else 'lb'
         result = {'total': {'energy': 0,
@@ -157,6 +162,7 @@ class NutritionPlan(models.Model):
             for i in result[key]:
                 result[key][i] = Decimal(result[key][i]).quantize(TWOPLACES)
 
+        cache.set(str(self.id), result)
         return result
 
     def get_closest_weight_entry(self):

--- a/wger/nutrition/signals.py
+++ b/wger/nutrition/signals.py
@@ -1,0 +1,18 @@
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from wger.nutrition.models import NutritionPlan, Meal, MealItem
+
+signals = [post_save, post_delete]
+
+
+@receiver(signals, sender=NutritionPlan)
+@receiver(signals, sender=Meal)
+@receiver(signals, sender=MealItem)
+def cache_deletion_on_change(sender, instance, **kwargs):
+    '''
+    Delete cache key when there is a change
+    in the nutrition plan, meals or mealitem
+    '''
+    plan = instance.get_owner_object()
+    cache.delete(plan.id)


### PR DESCRIPTION
### What does this PR do?
Allow caching for the nutrition plan information and delete cache on info change or delete

### Description of Task to be completed?
- [x] Add cache when nutrition plans are calculated.
- [x] Delete cache when a plan or related meal is deleted or edited.

### How should this be manually tested?
* Start the server by running `python manage.py runserver`
* Navigate to `http://127.0.0.1:8000/en/dashboard`
* Click on `Nutrition` -> `Nutrition plans`
* Click on `Sample nutrition plan`
* Click on `+ Add a new meal`. Note that ingredients should be selected from the dropdown list. Start typing a meal and wait for suggestions, then select from the available list. Save the plan.
* Add as many plans as you can for the same user(approximately 25)
* When saving and on first load of the browser you will notice that the speed is a bit slow 
* On the second load, the load speed has greatly improved.
* On editing or deleting a meal plan, the load speed is slow but those that follow are fast

### What are the relevant pivotal tracker stories?
[#166151254](https://www.pivotaltracker.com/story/show/166151254) 

### Screenshots
#### On creating a new meal or adding a meal item
<img width="1506" alt="Screenshot 2019-06-13 at 11 48 54" src="https://user-images.githubusercontent.com/45054246/59418223-58dbec80-8dd1-11e9-8265-d701190ceaef.png">


#### After reloading the site for the first time
<img width="1512" alt="Screenshot 2019-06-13 at 11 49 11" src="https://user-images.githubusercontent.com/45054246/59418256-65604500-8dd1-11e9-9c08-5b6d1be154ac.png">

*** Notice the top right load time recording of the browser in the screenshots

