### PR TITLE
#166672012 Add delete meals tests

### DIFF
--- a/wger/nutrition/tests/test_meal.py
+++ b/wger/nutrition/tests/test_meal.py
@@ -161,3 +161,47 @@ class MealApiTestCase(api_base_test.ApiBaseResourceTestCase):
     data = {'time': datetime.time(9, 2),
             'plan': 4,
             'order': 1}
+
+
+class DeleteMealTestCase(WorkoutManagerTestCase):
+    '''
+    Tests deleting meal
+    '''
+
+    def test_only_owner_can_delete_meal(self):
+        '''
+        Tests only meal owner can delete it
+        Non-owner is forbidden so 403 should be returned
+        '''
+
+        self.user_login('test')
+
+        url = reverse('nutrition:meal:delete',
+                      kwargs={'id': 5})
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        self.user_logout()
+
+        # check to confirm meal plan was not deleted
+        response = Meal.objects.filter(pk=5).exists()
+        self.assertEqual(response, True)
+
+    def test_delete_meal(self):
+        '''
+        Tests deleting a meal
+        It redirects on success so 302 should be returned
+        '''
+        self.user_login('admin')
+
+        url = reverse('nutrition:meal:delete', kwargs={'id': 5})
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+        self.user_logout()
+
+        # check to confirm meal plan was deleted
+        response = Meal.objects.filter(pk=5).exists()
+        self.assertEqual(response, False)


### PR DESCRIPTION
### What does this PR do?
There are no tests for deleting meals in the original code. This PR adds those tests.

### Description of Task to be completed?
- [x] Add tests for deleting meals.

### How should this be manually tested?
* Run tests by running `python manage.py test`

### What are the relevant pivotal tracker stories?
[#166672012](https://www.pivotaltracker.com/story/show/166672012) 

### Screenshots
**Before: (coverage of `meal.py` was at 85%)**
<img width="673" alt="Screenshot 2019-06-13 at 22 52 17" src="https://user-images.githubusercontent.com/19375569/59463248-417f1c80-8e2e-11e9-9ee1-0b87b90eb52c.png">

**After: (`meal.py` is now fully tested at 100%)**
<img width="664" alt="Screenshot 2019-06-13 at 22 53 54" src="https://user-images.githubusercontent.com/19375569/59463370-8014d700-8e2e-11e9-85e8-b2dddffdbcb3.png">