### PR TITLE
#166151253 display active and inactive users

### DIFF
--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -6,49 +6,112 @@
 <script>
 $(document).ready( function () {
     /* Make table sortable */
-    $('#main_member_list').DataTable({
+    $('#active_member_list').DataTable({
         paging: false,
         bFilter: true,
         bInfo : false
     });
+    $('#inactive_member_list').DataTable({
+        paging: false,
+        bFilter: true,
+        bInfo : false
+    });
+
+    $('#myTab a').on('click', function (e) {
+      e.preventDefault()
+      $(this).tab('show')
+    })
 });
 </script>
 
-<table class="table table-hover" id="main_member_list">
-<thead>
-<tr>
-    {% for key in user_table.keys %}
-        <th>{{ key }}</th>
-    {% endfor %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
-    {% endif %}
-</tr>
-{% endfor %}
-</tbody>
-</table>
+<ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" href="#active-users">Active Users</a></li>
+    <li><a data-toggle="tab" href="#inactive-users">Deactivated Users</a></li>
+</ul>
+
+<div class="tab-content mb-3">
+    <div id="active-users" class="tab-pane fade in active">
+        <table class="table table-hover" id="active_member_list">
+            <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+                <td data-order="{{current_user.last_log|date:'U'}}">
+                    {{current_user.last_log|default:'-/-'}}
+                </td>
+                {% if show_gym %}
+                <td>
+                    {% if current_user.obj.userprofile.gym_id %}
+                        <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                        {{ current_user.obj.userprofile.gym }}
+                        </a>
+                    {% else %}
+                        -/-
+                    {% endif %}
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div id="inactive-users" class="tab-pane fade">
+        <table class="table table-hover" id="inactive_member_list">
+            <thead>
+                <tr>
+                    {% for key in user_table.keys %}
+                        <th>{{ key }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if not current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+                <td data-order="{{current_user.last_log|date:'U'}}">
+                    {{current_user.last_log|default:'-/-'}}
+                </td>
+                {% if show_gym %}
+                <td>
+                    {% if current_user.obj.userprofile.gym_id %}
+                        <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                        {{ current_user.obj.userprofile.gym }}
+                        </a>
+                    {% else %}
+                        -/-
+                    {% endif %}
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
### What does this PR do?
- Adds a way to display active and inactive gym users

### Description of Task to be completed?
- [x] Create different tables for active and inactive users

### How should this be manually tested?
* Start the server by running `python manage.py runserver`
* Login as the admin user
* Navigate to `http://127.0.0.1:8000/en/gym/list`
* Add a new gym or just use the default gym
* Create Gym users and include trainers and managers
* Deactivate a member and they will appear on the deactivated table tab


ScreenShots
---
** Adding some members
Form to add members
<img width="716" alt="Screenshot 2019-06-18 at 06 50 34" src="https://user-images.githubusercontent.com/45054246/59652548-e5eac100-9196-11e9-860c-4dd68878d278.png">

Table after adding some members
<img width="1272" alt="Screenshot 2019-06-18 at 06 54 19" src="https://user-images.githubusercontent.com/45054246/59652369-1bdb7580-9196-11e9-8120-b67c62412595.png">


**Before:  How members active and inactive were displayed**
* Deactivate one gym member
After Deactivating a gym member, the member still displayed on the table
<img width="1234" alt="Screenshot 2019-06-18 at 06 54 05" src="https://user-images.githubusercontent.com/45054246/59652402-45949c80-9196-11e9-9f51-355769c6ce88.png">
*** Member still shows on the table of members
<img width="1272" alt="Screenshot 2019-06-18 at 06 54 19" src="https://user-images.githubusercontent.com/45054246/59652369-1bdb7580-9196-11e9-8120-b67c62412595.png">

**Now: Separate tables and tabs for active and deactivated members**
Table and tab for active members
<img width="624" alt="Screenshot 2019-06-18 at 06 03 17" src="https://user-images.githubusercontent.com/45054246/59652583-07e44380-9197-11e9-9432-442af726f6c7.png">

Table and tab for deactivated members
<img width="603" alt="Screenshot 2019-06-18 at 06 03 22" src="https://user-images.githubusercontent.com/45054246/59652592-0fa3e800-9197-11e9-96cb-5861aae1912e.png">


### What are the relevant pivotal tracker stories?
[#166672012](https://www.pivotaltracker.com/story/show/166151253) 