### PR TITLE
166151260 Filter exercises and ingredients by language

### DIFF
--- a/wger/core/templates/template.html
+++ b/wger/core/templates/template.html
@@ -215,6 +215,11 @@
 </footer>
 
 <script src="{% static 'bower_components/shariff/build/shariff.min.js' %}"></script>
+<script>
+    $(document).ready(function () {
+        $('#form-description').css({'display': 'none'})
+    })
+</script>
 </body>
 {% endspaceless_config %}
 </html>

--- a/wger/exercises/models.py
+++ b/wger/exercises/models.py
@@ -171,7 +171,8 @@ class Exercise(AbstractSubmissionModel, AbstractLicenseModel, models.Model):
         verbose_name=_('Category'), on_delete=models.CASCADE)
     description = models.TextField(max_length=2000,
                                    verbose_name=_('Description'),
-                                   validators=[MinLengthValidator(40)])
+                                   default='Keeps the body fit',
+                                   validators=[MinLengthValidator(10)])
     '''Description on how to perform the exercise'''
 
     name = models.CharField(max_length=200,

--- a/wger/exercises/templates/exercise/overview.html
+++ b/wger/exercises/templates/exercise/overview.html
@@ -8,7 +8,24 @@
 <!--
         Title
 -->
-{% block title %}{% trans "Exercises" %}{% endblock %}
+{% block title %}{% trans "Exercises" %}
+
+ <div class="btn-group" style="float:right; display: inline-block;">
+    <button id="filter-lang" type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+            {% trans "Filter Exercises by language " %}
+            <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'exercise:exercise:overview' %}>None</a></li>
+        {% for lan, language in languages %}
+        <li>
+            <a href={% url 'exercise:exercise:overview' %}?lang={{ lan }}><div id="lang">{{ language }}</div></a>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+
+ {% endblock %}
 
 
 
@@ -38,7 +55,7 @@ $(document).ready(function() {
 -->
 {% block content %}
 
-{% cache cache_timeout exercise-overview language.id %}
+{% cache 1 exercise-overview language.id %}
 {% regroup exercises by category as exercise_list %}
 <ul class="nav nav-tabs">
     {% for item in exercise_list %}

--- a/wger/exercises/tests/test_corrected_exercise.py
+++ b/wger/exercises/tests/test_corrected_exercise.py
@@ -35,6 +35,7 @@ class ExercisesCorrectionTestCase(WorkoutManagerTestCase):
              'name_original': 'my test exercise',
              'license': 2,
              'description': description,
+             'language': 1,
              'muscles': [3]})
 
         if fail:

--- a/wger/exercises/tests/test_exercise.py
+++ b/wger/exercises/tests/test_exercise.py
@@ -243,6 +243,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
                                     {'category': 2,
                                      'name_original': 'my test exercise',
                                      'license': 1,
+                                     'language': 1,
                                      'muscles': [1, 2]})
         count_after = Exercise.objects.count()
         self.assertIn(response.status_code, STATUS_CODES_FAIL)
@@ -267,6 +268,17 @@ class ExercisesTestCase(WorkoutManagerTestCase):
         self.add_exercise_user_fail()
         self.user_logout()
 
+    def filter_exercise_by_language(self, admin=False):
+        '''
+        Test items filtered by language
+        '''
+
+         # Add an exercise
+        count_before = Exercise.objects.count()
+        description = 'a nice, long and accurate description for the exercise'
+        response = self.client.post(reverse('exercise:exercise:overview'), params={lang: "en"})
+        self.assertEqual(response.status_code, 200)
+
     def add_exercise_success(self, admin=True):
         '''
         Tests adding/editing an exercise with a user with enough rights to do
@@ -280,6 +292,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
                                     {'category': 2,
                                      'name_original': 'my test exercise',
                                      'license': 1,
+                                     'language': 1,
                                      'description': description,
                                      'muscles': [1, 2]})
         count_after = Exercise.objects.count()
@@ -315,6 +328,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
                                     {'category': 111,
                                      'name_original': 'my test exercise',
                                      'license': 1,
+                                     'language': 1,
                                      'muscles': [1, 2]})
         self.assertTrue(response.context['form'].errors['category'])
 
@@ -324,6 +338,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
             {'category': 111,
              'name_original': 'my test exercise',
              'license': 1,
+             'language': 1,
              'muscles': [1, 2]})
         if admin:
             self.assertTrue(response.context['form'].errors['category'])
@@ -335,6 +350,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
                                     {'category': 1,
                                      'name_original': 'my test exercise',
                                      'license': 1,
+                                     'language': 1,
                                      'muscles': []})
         self.assertFalse(response.context['form'].errors.get('muscles'))
 
@@ -344,6 +360,7 @@ class ExercisesTestCase(WorkoutManagerTestCase):
             {'category': 1,
              'name_original': 'my test exercise',
              'license': 1,
+             'language': 1,
              'muscles': []})
         if admin:
             self.assertFalse(response.context['form'].errors.get('muscles'))

--- a/wger/nutrition/models.py
+++ b/wger/nutrition/models.py
@@ -251,7 +251,7 @@ class Ingredient(AbstractLicenseModel, models.Model):
 
     language = models.ForeignKey(Language,
                                  verbose_name=_('Language'),
-                                 editable=False, on_delete=models.CASCADE)
+                                 on_delete=models.CASCADE)
 
     user = models.ForeignKey(User,
                              verbose_name=_('User'),

--- a/wger/nutrition/templates/ingredient/overview.html
+++ b/wger/nutrition/templates/ingredient/overview.html
@@ -26,7 +26,23 @@
     </script>
 {% endblock %}
 
-{% block title %}{% trans "Ingredient overview" %}{% endblock %}
+{% block title %}{% trans "Ingredient overview" %}
+<div class="btn-group" style="float:right;">
+    <button id="filter-lang" type="button" class="btn btn-primary dropdown-toggle btn-xs" data-toggle="dropdown">
+        {% trans "Filter ingredient language" %}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+        <li><a href={% url 'nutrition:ingredient:list' %}>None</a></li>
+            {% for lan, language in languages %}
+            <li>
+                <a href={% url 'nutrition:ingredient:list' %}?lang={{ lan }}> {{ language }} </a>
+            </li>
+            {% endfor %}
+    </ul>
+</div>
+
+ {% endblock %}
 
 
 {% block content %}

--- a/wger/nutrition/tests/test_ingredient.py
+++ b/wger/nutrition/tests/test_ingredient.py
@@ -74,6 +74,7 @@ class EditIngredientTestCase(WorkoutManagerEditTestCase):
             'protein': 20,
             'carbohydrates': 10,
             'license': 2,
+            'language': 1,
             'license_author': 'me!'}
 
     def post_test_hook(self):
@@ -103,6 +104,7 @@ class AddIngredientTestCase(WorkoutManagerAddTestCase):
             'protein': 20,
             'carbohydrates': 10,
             'license': 2,
+            'language': 1,
             'license_author': 'me!'}
 
     def post_test_hook(self):
@@ -152,6 +154,15 @@ class IngredientDetailTestCase(WorkoutManagerTestCase):
         response = self.client.get(
             reverse('nutrition:ingredient:view', kwargs={'id': 42}))
         self.assertEqual(response.status_code, 404)
+
+    def filter_ingredient_by_language(self, editor=False):
+        '''
+        Tests the ingredient details page
+        '''
+
+        response = self.client.get(
+            reverse('nutrition:ingredient:view', params={lang: "en"}))
+        self.assertEqual(response.status_code, 200)
 
     def test_ingredient_detail_editor(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Filter exercises and ingredients by language

### Description of Task to be completed?
Every ingredient and exercise has a field indicating the language, which is automatically set as the user's current language when adding them. The current list is then filtered based on this. With this feature, the user is now able to select which languages to show which, in return, displays the exercises and ingredients created in that language.

### How should this be manually tested?
Clone the repository to your local branch
```
$ git clone https://github.com/andela/wg-baqi.git
```
$ cd to the `wg-baqi` directory, create a virtual environment and install the dependencies
```
$ cd wg-baqi
$ virtualenv venv
$ source venv/bin/activate
$ pip install -r requirements.txt
```
Activate bootstrap, make migrations and run the server
```
$ bower install
$ invoke bootstrap-wger --settings-path ./wger/settings.py --no-start-server
$ python manage.py runserver
```
- Log in to the application
- Navigate to the route `http://127.0.0.1:8000/en/exercise/overview/`
- Click on add an exercise, then specify the language for the exercise
<img width="933" alt="Screenshot 2019-06-18 at 20 40 53" src="https://user-images.githubusercontent.com/31995387/59706602-71049f00-9209-11e9-9874-2610944b1317.png">

- Click on `Filter Exercises by language` and choose the language you added the exercise to display
<img width="804" alt="Screenshot 2019-06-18 at 15 37 41" src="https://user-images.githubusercontent.com/31995387/59682500-0b9bb880-91df-11e9-8825-715aa86ca3e4.png">

- Change the language
<img width="807" alt="Screenshot 2019-06-18 at 15 38 26" src="https://user-images.githubusercontent.com/31995387/59682583-34bc4900-91df-11e9-998f-30bd37c0ed09.png">

#### The same procedure applies to ingredients


### What are the relevant pivotal tracker stories?
[#166151260](https://www.pivotaltracker.com/story/show/166151260) 