### PR TITLE
#166151270 enable trainer deactivation and delition by manager

### DIFF
--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -20,57 +20,122 @@
 
 
 <h4>{% trans "Administrators and trainers" %}</h4>
-<table class="table table-hover">
-<thead>
-<tr>
-    <th style="width: 10%;">{% trans "ID" %}</th>
-    <th style="width: 40%;">{% trans "Username" %}</th>
-    <th>{% trans "Name" %}</th>
-    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
-        <th style="text-align: right;">{% trans "Roles" %}</th>
-    {% endif %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in object_list.admins %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        {{current_user.obj}}
+<ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" href="#active-members">Active Members</a></li>
+    <li><a data-toggle="tab" href="#inactive-members">Inactive Members</a></li>
+</ul>
+<div class="tab-content mb-3">
+    <div id="active-members" class="tab-pane fade in active">
+        <table class="table table-hover">
+            <thead>
+            <tr>
+                <th style="width: 10%;">{% trans "ID" %}</th>
+                <th style="width: 40%;">{% trans "Username" %}</th>
+                <th>{% trans "Name" %}</th>
+                {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+                    <th style="text-align: right;">{% trans "Roles" %}</th>
+                {% endif %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in object_list.admins %}
+            {% if current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
 
-        {% if current_user.perms.gym_trainer %}
-            <span class="label label-primary">{% trans "Trainer" %}</span>
-        {% endif %}
+                    {% if current_user.perms.gym_trainer %}
+                        <span class="label label-primary">{% trans "Trainer" %}</span>
+                    {% endif %}
 
-        {% if current_user.perms.manage_gym %}
-            <span class="label label-primary">{% trans "Gym manager" %}</span>
-        {% endif %}
+                    {% if current_user.perms.manage_gym %}
+                        <span class="label label-primary">{% trans "Gym manager" %}</span>
+                    {% endif %}
 
-        {% if current_user.perms.manage_gyms %}
-            <span class="label label-primary">{% trans "General manager" %}</span>
-        {% endif %}
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
+                    {% if current_user.perms.manage_gyms %}
+                        <span class="label label-primary">{% trans "General manager" %}</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
 
-    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
-    <td style="text-align: right;">
-        <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
-            <span class="{% fa_class 'cog' %}"></span>
-        </a>
-    </td>
-    {% endif %}
-</tr>
-{% empty %}
-<tr>
-    <td colspan="4">{% trans "This gym has no administrators or trainers" %}</td>
-</tr>
-{% endfor %}
-</tbody>
-</table>
+                {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+                <td style="text-align: right;">
+                    <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
+                        <span class="{% fa_class 'cog' %}"></span>
+                    </a>
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% empty %}
+            <tr>
+                <td colspan="4">{% trans "This gym has no administrators or trainers" %}</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div id="inactive-members" class="tab-pane fade in">
+        <table class="table table-hover">
+            <thead>
+            <tr>
+                <th style="width: 10%;">{% trans "ID" %}</th>
+                <th style="width: 40%;">{% trans "Username" %}</th>
+                <th>{% trans "Name" %}</th>
+                {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+                    <th style="text-align: right;">{% trans "Roles" %}</th>
+                {% endif %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in object_list.admins %}
+            {% if not current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+
+                    {% if current_user.perms.gym_trainer %}
+                        <span class="label label-primary">{% trans "Trainer" %}</span>
+                    {% endif %}
+
+                    {% if current_user.perms.manage_gym %}
+                        <span class="label label-primary">{% trans "Gym manager" %}</span>
+                    {% endif %}
+
+                    {% if current_user.perms.manage_gyms %}
+                        <span class="label label-primary">{% trans "General manager" %}</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+
+                {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+                <td style="text-align: right;">
+                    <a href="{% url 'gym:gym:edit-user-permission' current_user.obj.pk %}" class="btn btn-default btn-xs wger-modal-dialog">
+                        <span class="{% fa_class 'cog' %}"></span>
+                    </a>
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% empty %}
+            <tr>
+                <td colspan="4">{% trans "This gym has no administrators or trainers" %}</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
 {% endblock %}
 
 

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -6,49 +6,112 @@
 <script>
 $(document).ready( function () {
     /* Make table sortable */
-    $('#main_member_list').DataTable({
+    $('#active_member_list').DataTable({
         paging: false,
         bFilter: true,
         bInfo : false
     });
+    $('#inactive_member_list').DataTable({
+        paging: false,
+        bFilter: true,
+        bInfo : false
+    });
+
+    $('#myTab a').on('click', function (e) {
+      e.preventDefault()
+      $(this).tab('show')
+    })
 });
 </script>
 
-<table class="table table-hover" id="main_member_list">
-<thead>
-<tr>
-    {% for key in user_table.keys %}
-        <th>{{ key }}</th>
-    {% endfor %}
-</tr>
-</thead>
-<tbody>
-{% for current_user in user_table.users %}
-<tr>
-    <td>
-        {{current_user.obj.pk}}
-    </td>
-    <td>
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
-    </td>
-    <td>
-        {{current_user.obj.get_full_name}}
-    </td>
-    <td data-order="{{current_user.last_log|date:'U'}}">
-        {{current_user.last_log|default:'-/-'}}
-    </td>
-    {% if show_gym %}
-    <td>
-        {% if current_user.obj.userprofile.gym_id %}
-            <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
-            {{ current_user.obj.userprofile.gym }}
-            </a>
-        {% else %}
-            -/-
-        {% endif %}
-    </td>
-    {% endif %}
-</tr>
-{% endfor %}
-</tbody>
-</table>
+<ul class="nav nav-tabs">
+    <li class="active"><a data-toggle="tab" href="#active-users">Active Users</a></li>
+    <li><a data-toggle="tab" href="#inactive-users">Deactivated Users</a></li>
+</ul>
+
+<div class="tab-content mb-3">
+    <div id="active-users" class="tab-pane fade in active">
+        <table class="table table-hover" id="active_member_list">
+            <thead>
+            <tr>
+                {% for key in user_table.keys %}
+                    <th>{{ key }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+                <td data-order="{{current_user.last_log|date:'U'}}">
+                    {{current_user.last_log|default:'-/-'}}
+                </td>
+                {% if show_gym %}
+                <td>
+                    {% if current_user.obj.userprofile.gym_id %}
+                        <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                        {{ current_user.obj.userprofile.gym }}
+                        </a>
+                    {% else %}
+                        -/-
+                    {% endif %}
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div id="inactive-users" class="tab-pane fade">
+        <table class="table table-hover" id="inactive_member_list">
+            <thead>
+                <tr>
+                    {% for key in user_table.keys %}
+                        <th>{{ key }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+            {% for current_user in user_table.users %}
+            {% if not current_user.obj.is_active %}
+            <tr>
+                <td>
+                    {{current_user.obj.pk}}
+                </td>
+                <td>
+                    <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+                </td>
+                <td>
+                    {{current_user.obj.get_full_name}}
+                </td>
+                <td data-order="{{current_user.last_log|date:'U'}}">
+                    {{current_user.last_log|default:'-/-'}}
+                </td>
+                {% if show_gym %}
+                <td>
+                    {% if current_user.obj.userprofile.gym_id %}
+                        <a href="{{ current_user.obj.userprofile.gym.get_absolute_url }}">
+                        {{ current_user.obj.userprofile.gym }}
+                        </a>
+                    {% else %}
+                        -/-
+                    {% endif %}
+                </td>
+                {% endif %}
+            </tr>
+            {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>


### PR DESCRIPTION
### What does this PR do?
- Adds a way manager ability to delete and deactivate trainer

### Description of Task to be completed?
- [x] Enable deleting and deactivation of trainers
- [x] Display active and inactive trainers on different views

### How should this be manually tested?
* Start the server by running `python manage.py runserver`
* Login as the admin user
* Navigate to `http://127.0.0.1:8000/en/gym/list`
* Add a new gym or just use the default gym
* Create Gym users and include trainers and managers
* Login as a gym manager you created
* Click on the link with the trainer's name
* Select deactivate or delete in the options dropdown


ScreenShots
---
Initially, Gym Trainers and managers pages would not be accessed
<img width="660" alt="Screenshot 2019-06-18 at 23 15 56" src="https://user-images.githubusercontent.com/45054246/59836105-9f8e9100-9353-11e9-9ee8-5d24e6d77109.png">

After adding links to view accounts
<img width="590" alt="Screenshot 2019-06-18 at 23 16 14" src="https://user-images.githubusercontent.com/45054246/59836415-26dc0480-9354-11e9-9deb-3d1f3ca78d1e.png"> 

Options bar is only available when logged in by admin for trainer
<img width="988" alt="Screenshot 2019-06-20 at 11 43 30" src="https://user-images.githubusercontent.com/45054246/59836580-6efb2700-9354-11e9-81d5-ab2906c3b06a.png">

After deactivating a user
<img width="1038" alt="Screenshot 2019-06-20 at 10 46 12" src="https://user-images.githubusercontent.com/45054246/59837251-9a324600-9355-11e9-8170-06c8458642f4.png">

When deleting a user
<img width="1228" alt="Screenshot 2019-06-20 at 10 45 37" src="https://user-images.githubusercontent.com/45054246/59837289-a918f880-9355-11e9-9cb5-4e7e15e8ba8e.png">


### What are the relevant pivotal tracker stories?
[#166672012](https://www.pivotaltracker.com/story/show/166151270) 